### PR TITLE
Amended Dockerfile with recommends from dnf/Docker and npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM asciidoctor/docker-asciidoctor
-RUN dnf install -y hostname npm bzip2
-RUN npm install -g phantomjs
+RUN dnf install -y hostname npm bzip2 && dnf clean all
+RUN npm install -g phantomjs-prebuilt
 RUN npm install -g mermaid
 ADD . /book
 WORKDIR /book


### PR DESCRIPTION
NPM now suggests installing `phantom-prebuilt` instead.
`dnf clean all` recommended by Dockerfile guidelines